### PR TITLE
removed comma in vb veos json

### DIFF
--- a/VirtualBox/vEOS.json
+++ b/VirtualBox/vEOS.json
@@ -145,6 +145,6 @@
               [ "storageattach","{{.Name}}","--storagectl","IDE","--port","0","--device","1","--type","dvddrive","--medium","source/Aboot-veos-2.0.8.iso" ]
           ],
           "shutdown_command":"bash reload now"
-      },
+      }
    ]
 }


### PR DESCRIPTION
the comma was resulting in
`

> packer build --parallel=false vEOS.json
> Failed to parse template: Error in line 149, char 3: invalid character ']' looking for beginning of value
>    ]
> `
